### PR TITLE
(WiP) Top down islands

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,28 @@
 <!doctype html>
 <html>
   <head>
-    <script src=//unpkg.com/patchinko/immutable.js></script>
-    <script defer type=module src=playground.mjs></script>
+    <meta chartset=utf-8>
+    <title>Proponents</title>
   </head>
+  <body style=font-family:sans-serif>
+    <ul>
+      <li>
+        <a href=src/packages/Island>
+          Island
+        </a>
+        <ul>
+          <li>
+            <a href=src/packages/Island/demo>
+              demo
+            </a>
+          </li>
+          <li>
+            <a href=src/packages/Island/tests>
+              test suite
+            </a>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "cascading-components",
-  "version": "0.0.2",
+  "name": "proponents",
+  "version": "0.0.3",
   "description": "Low-level utility components for Mithril",
   "main": "index.js",
   "dependencies": {
@@ -10,14 +10,13 @@
     "mithril": "^1.0.0"
   },
   "devDependencies": {
+    "http-server": "^0.11.1",
     "mithril": "^1.1.6",
-    "symlink-dir": "^1.1.2",
-    "zwitterion": "^0.27.0"
+    "symlink-dir": "^1.1.2"
   },
   "scripts": {
-    "install": "symlink-dir src node_modules/src",
-    "start": "zwitterion -w --target ESNext",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "http-server -o",
+    "test": "echo \"To test Proponents, please run 'npm start' and navigate to the desired tests\" && exit 1"
   },
   "repository": {
     "type": "git",

--- a/src/packages/Inline/src/index.js
+++ b/src/packages/Inline/src/index.js
@@ -1,6 +1,12 @@
-export default function(v){
+try {
+   module.exports = Inline
+}
+catch(e){}
+
+
+function Inline(v){
   const f = (
-      v.children[0] 
+      v && v.children && v.children[0]
     &&
       typeof v.children[0].children === 'function'
     &&
@@ -13,9 +19,9 @@ export default function(v){
       (
           f.prototype && f.prototype.view
         ?
-          new f(...arguments)
+          new f(v)
         :
-          f(...arguments)
+          f(v)
       )
     :
       {
@@ -23,7 +29,7 @@ export default function(v){
           return (
               v.attrs.view
             ?
-              v.attrs.view(...arguments)
+              v.attrs.view(v)
             :
               v.attrs.children
           )

--- a/src/packages/Inline/src/index.mjs
+++ b/src/packages/Inline/src/index.mjs
@@ -1,0 +1,33 @@
+export default function(v){
+  const f = (
+      v && v.children && v.children[0]
+    &&
+      typeof v.children[0].children === 'function'
+    &&
+      v.children[0].children
+  )
+
+  return (
+      f
+    ?
+      (
+          f.prototype && f.prototype.view
+        ?
+          new f(v)
+        :
+          f(v)
+      )
+    :
+      {
+        view(v){
+          return (
+              v.attrs.view
+            ?
+              v.attrs.view(v)
+            :
+              v.attrs.children
+          )
+        }
+      }
+  )
+}

--- a/src/packages/Island/README.md
+++ b/src/packages/Island/README.md
@@ -1,0 +1,43 @@
+# Island
+
+`Island` creates an isolated redraw context which can be redrawn independently of the supertree. This is useful for components that need to redraw many times in quick succession without wanting to cause the whole application view to recompute (ideal for expressing animations in virtual DOM).
+
+It consumes a child function which defines the subtree. That function receives a hash containing
+
+* a `redraw` function which can be called to redraw that component without redrawing the supertree
+* a `local` boolean flag which can be used to determine if the current draw loop was triggered by such a request or not
+* a `first` boolean flag which is only true on the initial draw
+
+Here's
+
+```js
+const frame = () =>
+  new Promise(requestAnimationFrame)
+
+const MyComponent = () => {
+  let completion = 0
+
+  return {
+    view: () =>
+      m(Island, ({redraw, local}) =>
+        m('div', {
+          style: {
+            height : completion + '%',
+            opacity: completion / 100,
+          },
+          async oninit : () => {
+            while(completion++ < 100){
+              await frame()
+
+              redraw()
+            }
+          },
+        },
+          m(SubComponent, {
+            onbeforeupdate: () => !local,
+          })
+        )
+      )
+  }
+}
+```

--- a/src/packages/Island/demo/index.html
+++ b/src/packages/Island/demo/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset=utf-8>
+    <title>
+      Island demo
+    </title>
+    <meta name=description content="
+      Simple Island demonstration
+    ">
+  </head>
+  <body>
+    <script src=//unpkg.com/patchinko/immutable.js></script>
+    <script src=//unpkg.com/mithril/mithril.js></script>
+    <script type=module src=index.mjs></script>
+    <script    nomodule src=../../Inline/src/index.js></script>
+    <script    nomodule src=../../Island/src/index.js></script>
+    <script    nomodule src=index.js></script>
+  </body>
+</html>

--- a/src/packages/Island/demo/index.js
+++ b/src/packages/Island/demo/index.js
@@ -1,0 +1,92 @@
+const frame = () =>
+  new Promise(requestAnimationFrame)
+
+const Counter = {
+  ...Inline(),
+  counter: 0,
+}
+
+m.mount(document.documentElement, () => {
+  let key   = 0
+  let draws = 0
+
+  return {
+    oncreate: () => {
+      window.initial = document.documentElement.vnodes
+    },
+    view: () => [
+      m('head',
+        m('style', `
+          body {
+            font-family :sans-serif
+          }
+        `)
+      ),
+
+      m('body',
+        m('h1', 'Island component demo'),
+
+        m('p', 'This is a demonstration of the ', m('code', 'Island'), ' component.'),
+
+        m('p', 'We also use the ', m('code', 'Inline'), ' component for the purpose of holding state in a series of nested, single-use components. Please read the source for more information.'),
+
+        m('p', 'External component (drawn ', ++draws, ' times)'),
+
+        m('button', {
+          onclick: e => {
+            key++
+          },
+        }, 'Re-initialise the Island?'),
+
+        m('button', {
+          onclick: e => {},
+        }, 'No-op redraw'),
+
+        [
+          m(Inline, {key}, () => {
+            let animation = 0
+
+            return {
+              view: () =>
+                m(Island, ({redraw, local}) =>
+                  m('p', {
+                    key,
+                    style  : {
+                      border    : '1px solid',
+                      padding   : '1em',
+                      transform : 'scale(' + animation / 200 + ')',
+                      opacity   : animation / 200,
+                    },
+                    oninit : async () => {
+                      while(animation < 200){
+                        await frame()
+
+                        animation++
+
+                        redraw()
+                      }
+                    },
+                  },
+                    'Island draws: ', animation,
+
+                    m('br'),
+
+                    m(Counter, {
+                      onbeforeupdate: () =>
+                        !local,
+
+                      view: ({state}) => [
+                        'Nested component (drawn ',
+                        ++state.counter,
+                        ' times)',
+                      ],
+                    }),
+                  )
+                )
+            }
+          }),
+        ],
+      ),
+    ]
+  }
+})

--- a/src/packages/Island/demo/index.mjs
+++ b/src/packages/Island/demo/index.mjs
@@ -1,0 +1,95 @@
+import Inline from '/src/packages/Inline/src/index.mjs'
+import Island from '/src/packages/Inline/src/index.mjs'
+
+const frame = () =>
+  new Promise(requestAnimationFrame)
+
+const Counter = {
+  ...Inline(),
+  counter: 0,
+}
+
+m.mount(document.documentElement, () => {
+  let key   = 0
+  let draws = 0
+
+  return {
+    oncreate: () => {
+      window.initial = document.documentElement.vnodes
+    },
+    view: () => [
+      m('head',
+        m('style', `
+          body {
+            font-family :sans-serif
+          }
+        `)
+      ),
+
+      m('body',
+        m('h1', 'Island component demo'),
+
+        m('p', 'This is a demonstration of the ', m('code', 'Island'), ' component.'),
+
+        m('p', 'We also use the ', m('code', 'Inline'), ' component for the purpose of holding state in a series of nested, single-use components. Please read the source for more information.'),
+
+        m('p', 'External component (drawn ', ++draws, ' times)'),
+
+        m('button', {
+          onclick: e => {
+            key++
+          },
+        }, 'Re-initialise the Island?'),
+
+        m('button', {
+          onclick: e => {},
+        }, 'No-op redraw'),
+
+        [
+          m(Inline, {key}, () => {
+            let animation = 0
+
+            return {
+              view: () =>
+                m(Island, ({redraw, local}) =>
+                  m('p', {
+                    key,
+                    style  : {
+                      border    : '1px solid',
+                      padding   : '1em',
+                      transform : 'scale(' + animation / 200 + ')',
+                      opacity   : animation / 200,
+                    },
+                    oninit : async () => {
+                      while(animation < 200){
+                        await frame()
+
+                        animation++
+
+                        redraw()
+                      }
+                    },
+                  },
+                    'Island draws: ', animation,
+
+                    m('br'),
+
+                    m(Counter, {
+                      onbeforeupdate: () =>
+                        !local,
+
+                      view: ({state}) => [
+                        'Nested component (drawn ',
+                        ++state.counter,
+                        ' times)',
+                      ],
+                    }),
+                  )
+                )
+            }
+          }),
+        ],
+      ),
+    ]
+  }
+})

--- a/src/packages/Island/package.json
+++ b/src/packages/Island/package.json
@@ -2,20 +2,21 @@
   "name": "mithril-island",
   "version": "0.0.1",
   "description": "Redraw individual components without affecting the surrounding tree",
-  "main": "index.js",
+  "main": "src/index.js",
+  "module": "src/index.mjs",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/barneycarroll/cascading-components.git"
+    "url": "git+ssh://git@github.com/barneycarroll/proponents.git"
   },
   "author": "Barney Carroll <barney.carroll@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/barneycarroll/cascading-components/issues"
+    "url": "https://github.com/barneycarroll/proponents/issues"
   },
-  "homepage": "https://github.com/barneycarroll/cascading-components#readme",
+  "homepage": "https://github.com/barneycarroll/proponents#readme",
   "peerDependencies": {
     "mithril": "^1.1.6",
     "patchinko": "^3.2.1"

--- a/src/packages/Island/src/index.js
+++ b/src/packages/Island/src/index.js
@@ -1,0 +1,185 @@
+try {
+  module.exports = Island
+
+  var m = require('mithril')
+  var O = require('patchinko/immutable')
+}
+catch(e){}
+
+function Island(v){
+  // Internal
+  let root   // Nearest ancestral mount-point
+  let path   // v's position within container
+  let vnodes // Root vnodes as of last check
+  let temp   // Variation of vnodes with components from root to target removed
+
+  // Flags to qualify nature of current draw loop
+  let first = true
+  let local = false
+
+  return {
+    oncreate: tick,
+    onupdate: tick,
+
+    view,
+  }
+
+  // Refresh & reset references
+  function tick(fresh){
+    v = fresh
+  }
+
+  function view(){
+    return v.children[0].children({first, local, redraw})
+  }
+
+  // Overload redraw function
+  function redraw(handler){
+    // Manual, explicit redraw
+    if(typeof handler !== 'function')
+      render()
+
+    // Event handler wrapper: inverts Mithril auto-redraw directives:
+    else
+      return function(e){
+        const output = handler(...arguments)
+
+        // Unless e.redraw was set to false, redraw
+        if(e.redraw !== false)
+          render()
+
+        // Prevent global redraw
+        e.redraw = false
+
+        return output
+      }
+  }
+
+  function render(){
+    if(!v.dom || !v.dom.parentNode)
+      root = [...document.all].find(node => node.vnodes)
+
+    if(!root)
+      root = findRoot(v.dom)
+
+    local = true
+
+    // Determine whether a global redraw took place after last local draw
+    if(vnodes !== root.vnodes){
+      // Refresh all dependent references
+      vnodes = root.vnodes
+      path   = findWithinRoot(v, root).reverse()
+      temp   = O(
+        vnodes,
+        path.reduce(
+          decompose,
+          v.instance,
+        ),
+      )
+    }
+
+    // Get our new component instance
+    const instance = view()
+
+    // Clear state flags
+    first = false
+    local = false
+
+    // Temporarily swap vnodes for a variation without components
+    // to avoid view re-executions
+    root.vnodes = temp
+
+    temp  = O(
+      vnodes,
+      path.reduce(
+        decompose,
+        instance,
+      ),
+    )
+
+    // Trace the path from our (new) local instance up to the root
+    // and clone each node in the path for a replacement tree.
+    // This ensures a 'hot path', ensuring uncloned siblings aren't redrawn.
+    // Render the patched local container + our new local draw
+    m.render(root, temp)
+
+    // Recompose the tree to match higher order draw expectations
+    vnodes = root.vnodes = O(
+      vnodes,
+      path.reduce(
+        (patch, key) => ({
+          [key]: O(patch)
+        }),
+
+        O(v, {
+          instance: [...path].reverse().reduce(
+            recompose,
+            temp,
+          ),
+        }),
+      ),
+    )
+  }
+}
+
+const findRoot = element => {
+  while(!element.vnodes)
+    element = element.parentNode
+
+  return element
+}
+
+const findWithinRoot = (target, root) => {
+  for(const {node, path} of crawl({node: root.vnodes}))
+    if(node === target)
+      return path
+}
+
+function* crawl({ node, stack = [], path = [] }) {
+  yield { node, path }
+
+  if (Array.isArray(node)) {
+    let index = node.length
+
+    while (index--)
+      stack.push({
+        path: [...path, index],
+        node: node[index],
+      })
+  }
+
+  else if (node.instance)
+    stack.push({
+      path: [...path, 'instance'],
+      node: node.instance,
+    })
+
+  else if (node.children)
+    stack.push({
+      path: [...path, 'children'],
+      node: node.children,
+    })
+
+  while (stack.length)
+    yield* crawl(stack.pop())
+}
+
+const decompose = (patch, key) => (
+    key === 'instance'
+  ?
+    ({instance}) => O(
+      m.fragment({}, []),
+
+      {children: [O(instance, patch)]},
+    )
+  :
+    {[key]: O(patch)}
+)
+
+const recompose = (node, key) => (
+    key == 'instance'
+  ?
+    node.children[0]
+  :
+    node[key]
+)

--- a/src/packages/Island/src/index.mjs
+++ b/src/packages/Island/src/index.mjs
@@ -11,23 +11,11 @@ export default v => {
   let local = false
 
   return {
-    oncreate: tick,
-    onupdate: tick,
+    onupdate: fresh => {
+      v = fresh
+    },
 
     view,
-  }
-
-  // Refresh & reset references
-<<<<<<< HEAD:src/packages/Island/src/index.mjs
-  function tick(fresh){
-    v = fresh
-=======
-  function tick(fresh) {
-    v     = fresh
-
-    first = false
-    local = false
->>>>>>> 6f1aeaf627bdefcc333e1682f759b5c1f776a3bd:src/packages/Island/index.mjs
   }
 
   function view() {
@@ -167,7 +155,6 @@ function* crawl({ node, stack = [], path = [] }) {
 
 const decompose = (patch, key) => (
     key === 'instance'
-<<<<<<< HEAD:src/packages/Island/src/index.mjs
   ?
     ({instance}) => O(
       m.fragment({}, []),
@@ -182,14 +169,6 @@ const recompose = (node, key) => (
     key == 'instance'
   ?
     node.children[0]
-=======
-  ?
-    ({ instance }) => O(
-      m.fragment({}, []),
-
-      { children: [O(instance, patch)] },
-    )
->>>>>>> 6f1aeaf627bdefcc333e1682f759b5c1f776a3bd:src/packages/Island/index.mjs
   :
     node[key]
 )

--- a/src/packages/Island/tests/index.html
+++ b/src/packages/Island/tests/index.html
@@ -1,9 +1,18 @@
 <!doctype html>
 <html>
+  <head>
+    <meta charset=utf-8>
+    <title>
+      Island test suite
+    </title>
+    <meta name=description content="
+      Open the console to see the test suite report
+    ">
+  </head>
   <body>
     <script src=//unpkg.com/patchinko/immutable.js></script>
     <script src=//unpkg.com/mithril/mithril.js></script>
-    <script src=//rawgit.com/MithrilJS/mithril.js/ospec-async-fix/ospec/ospec.js></script>
+    <script src=//rawgit.com/MithrilJS/mithril.js/next/ospec/ospec.js></script>
     <script type=module src=index.mjs></script>
   </body>
 </html>


### PR DESCRIPTION
Will eventually fix #8 & #11. Currently broken because of the need to perform a hacky patch, the exact mechanism of which remains elusive: in short, the hot-path from the root vnodes down to the Island must be 'decomposed' - ie a real-DOM-equivalent tree must be fashioned which excludes all component vnodes between the root and the Island contents, in order to avoid `m.render` triggering the views for each of these.

I attempted to do this with a clever reduce function but there were caveats:
* Nested `O(patch)` Patchinko operations weren't unwrapped
* The recursive Patchinko operation doesn't address the mismatch between the `root.vnodes` structure & the desired patch - couldn't find a way to establish that the component nodes need their contents 'bringing up' a level.